### PR TITLE
janx/ubuntu-dev → janitortechnology/ubuntu-dev

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM janx/ubuntu-dev
+FROM janitortechnology/ubuntu-dev
 MAINTAINER Raphael Catolino "raphael.catolino@gmail.com"
 
 ENV SHELL /bin/bash


### PR DESCRIPTION
The `janx/ubuntu-dev` image was recently renamed.